### PR TITLE
Improve commit & pull request messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,3 @@ This repo contains the source for builder images to be used as steps in CI/CD pi
 ### Testing
 Each directory for an image contains an image structure test to confirm that it will build correctly using the [Google Container Structure Test](https://github.com/GoogleContainerTools/container-structure-test) and Skaffold. You can build and test all the containers by running `skaffold build` or `make`.
 
-**test**

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ This repo contains the source for builder images to be used as steps in CI/CD pi
 
 ### Testing
 Each directory for an image contains an image structure test to confirm that it will build correctly using the [Google Container Structure Test](https://github.com/GoogleContainerTools/container-structure-test) and Skaffold. You can build and test all the containers by running `skaffold build` or `make`.
+
+**test**

--- a/builder-image-gitops/go/src/gitops/main.go
+++ b/builder-image-gitops/go/src/gitops/main.go
@@ -73,10 +73,7 @@ func gitCommit(worktree *git.Worktree, file string) (err error) {
 		return
 	}
 
-  val,exists:= os.LookupEnv("GIT_URL")
-  if exists {
-    val = createGitMessage("commit")
-  }
+  val = createGitMessage("commit")
 
 
 	fmt.Println("Commiting changes")

--- a/builder-image-gitops/go/src/gitops/main.go
+++ b/builder-image-gitops/go/src/gitops/main.go
@@ -73,7 +73,7 @@ func gitCommit(worktree *git.Worktree, file string) (err error) {
 		return
 	}
 
-  val = createGitMessage("commit")
+  val := createGitMessage("commit")
 
 
 	fmt.Println("Commiting changes")

--- a/builder-image-gitops/go/src/gitops/main.go
+++ b/builder-image-gitops/go/src/gitops/main.go
@@ -73,8 +73,15 @@ func gitCommit(worktree *git.Worktree, file string) (err error) {
 		return
 	}
 
+  val,exists:= os.LookupEnv("GIT_URL")
+  if exists {
+    source := strings.Split(strings.SplitN(val, "/", 4)[3], ".")
+    val = " from " + source[0]
+  }
+
+
 	fmt.Println("Commiting changes")
-	worktree.Commit(fmt.Sprintf("GitOps: Update %s", file), &git.CommitOptions{
+	worktree.Commit(fmt.Sprintf("GitOps: Update %s%s", file, val), &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "GitOps Automation",
 			Email: "gitops@liatr.io",
@@ -94,20 +101,48 @@ func gitPush(repo *git.Repository, auth transport.AuthMethod) (err error) {
 }
 
 func githubPullRequest(httpClient *http.Client, org string, repo string, branch *plumbing.Reference) (pullRequest *github.PullRequest, err error) {
-	fmt.Printf("Create pull request for branch %s\n", branch.Name().Short())
+  fmt.Printf("Create pull request for branch %s\n", branch.Name().Short())
 	client := github.NewClient(httpClient)
+
+
 
 	newPR := &github.NewPullRequest{
 		Title:               github.String("GitOps"),
 		Head:                github.String(branch.Name().Short()),
 		Base:                github.String("master"),
-		Body:                github.String("This pull request was automatically generated https://github.com/liatrio/builder-images/tree/master/builder-image-gitops"),
+		Body:                github.String(createPullRequestMessage()),
 		MaintainerCanModify: github.Bool(true),
 	}
 
 	pullRequest, _, err = client.PullRequests.Create(context.Background(), org, repo, newPR)
 
 	return
+}
+
+func createPullRequestMessage() (pullRequestMessage string) {
+  val,exists:= os.LookupEnv("GIT_URL")
+  if exists {
+    source := strings.Split(strings.SplitN(val, "/", 4)[3], ".")
+    message := "This pull request was automatically generated from the pipeline of the repo " + source[0] + "\n\n"
+
+    gitAuth := &githttp.BasicAuth{
+      Username: os.Getenv("GITOPS_GIT_USERNAME"),
+      Password: os.Getenv("GITOPS_GIT_PASSWORD"),
+    }
+
+    sourceRepo, err := gitClone(val, gitAuth, "/home/jenkins/sourceRepo")
+    CheckIfError(err)
+
+    ref, err := sourceRepo.Head()
+    CheckIfError(err)
+
+    cIter, err := sourceRepo.Log(&git.LogOptions{From: ref.Hash()})
+    CheckIfError(err)
+
+    c, err := cIter.Next()
+    return message + c.String()
+  }
+  return "This pull request was automatically generated https://github.com/liatrio/builder-images/tree/master/builder-image-gitops"
 }
 
 func parseFile(filePath string) (*ast.File, error) {


### PR DESCRIPTION
Added the name of the repo making the pull request to the PR and commit messages, as well as the most recent commit message of the repo to the pull request message. This only works if there is an env var named GIT_URL with the source repo. Otherwise the generic messages are used.