### PR TITLE
ENG 1640 Helm 3

### DIFF
--- a/builder-image-skaffold/Dockerfile
+++ b/builder-image-skaffold/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 		openssh-client \
 		make
 
-ENV SKAFFOLD_VERSION 0.38.0
+ENV SKAFFOLD_VERSION 1.6.0
 RUN curl -f -Lo skaffold https://github.com/GoogleCloudPlatform/skaffold/releases/download/v${SKAFFOLD_VERSION}/skaffold-linux-amd64 && \
   chmod +x skaffold && \
   mv skaffold /usr/bin

--- a/builder-image-skaffold/Dockerfile
+++ b/builder-image-skaffold/Dockerfile
@@ -17,8 +17,8 @@ RUN curl -f -Lo container-structure-test https://storage.googleapis.com/containe
   chmod +x container-structure-test && \
   mv container-structure-test /usr/bin
 
-ENV HELM_VERSION 2.14.1
-RUN curl -f -L https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar -zx && \
+ENV HELM_VERSION 3.1.2
+RUN curl -f -L https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar -zx && \
   chmod +x linux-amd64/helm && \
   mv linux-amd64/helm /usr/bin && \
   rm -rf linux-amd64

--- a/builder-image-skaffold/test/builder-image-skaffold.yaml
+++ b/builder-image-skaffold/test/builder-image-skaffold.yaml
@@ -4,7 +4,7 @@ commandTests:
   - name: "skaffold version"
     command: "skaffold"
     args: ["version"]
-    expectedOutput: ["v0\\.38\\.0"]
+    expectedOutput: ["v1\\.6\\.0"]
     exitCode: 0
   - name: "container-structure-test version"
     command: "container-structure-test"


### PR DESCRIPTION
# Skaffold Builder Image

Bumps Helm to version 3.1.2, to support Tiller free deployments.
Bumps Skaffold to version 1.6.0 to support Helm 3 deployments.