### PR TITLE
ci: Update gitops manifest path

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,5 +23,5 @@ jobs:
         url: https://github.com/liatrio/lead-environments.git
         username: ${{ github.actor }}
         password: ${{ secrets.GITTY_UP_TOKEN }}
-        file: aws/manifest.yml
-        values: liatrio_sandbox.builder_images_version=${{steps.gitextra.outputs.version}}:liatrio_sandbox.jenkins_image_version=${{steps.gitextra.outputs.version}}
+        file: aws/liatrio-sandbox/manifest.yml
+        values: builder_images_version=${{steps.gitextra.outputs.version}}:jenkins_image_version=${{steps.gitextra.outputs.version}}


### PR DESCRIPTION
The location and layout of the manifest changed in https://github.com/liatrio/lead-environments/pull/608